### PR TITLE
Changed the Scala classes to case classes

### DIFF
--- a/pet-clinic-java/src/main/java/com/github/rskupnik/petclinic/model/Customer.java
+++ b/pet-clinic-java/src/main/java/com/github/rskupnik/petclinic/model/Customer.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class Customer {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     private Long id;
     private String firstName, lastName;
 

--- a/pet-clinic-java/src/main/java/com/github/rskupnik/petclinic/model/Pet.java
+++ b/pet-clinic-java/src/main/java/com/github/rskupnik/petclinic/model/Pet.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 public class Pet {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     private Long id;
     private String name;
 

--- a/pet-clinic-kotlin/src/main/kotlin/com/github/rskupnik/petclinic/model/Customer.kt
+++ b/pet-clinic-kotlin/src/main/kotlin/com/github/rskupnik/petclinic/model/Customer.kt
@@ -9,7 +9,7 @@ import javax.persistence.*
 // 2. Entity classes need a default constructor - one is provided here by giving all the arguments a default value
 @Entity
 data class Customer(
-        @Id @GeneratedValue(strategy = GenerationType.AUTO)
+        @Id @GeneratedValue
         var id: Long = 0,
 
         var firstName: String = "",

--- a/pet-clinic-kotlin/src/main/kotlin/com/github/rskupnik/petclinic/model/Pet.kt
+++ b/pet-clinic-kotlin/src/main/kotlin/com/github/rskupnik/petclinic/model/Pet.kt
@@ -17,7 +17,7 @@ class Pet {
     }
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     var id: Long = 0
 
     var name: String = ""

--- a/pet-clinic-scala/src/main/scala/com/github/rskupnik/model/Customer.scala
+++ b/pet-clinic-scala/src/main/scala/com/github/rskupnik/model/Customer.scala
@@ -4,35 +4,32 @@ import javax.persistence._
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 
+import scala.annotation.meta.field
 import scala.beans.BeanProperty
 
+// BeanProperty needed to generate getters and setters
+
 @Entity
-class Customer {
+case class Customer(
+                     @(Id@field)
+                     @(GeneratedValue@field)
+                     @BeanProperty
+                     var id: Long,
+                     @BeanProperty
+                     var firstName: String,
+                     @BeanProperty
+                     var lastName: String) {
 
-  // Need to specify a parameterized constructor explicitly
-  def this(firstName: String, lastName: String) {
-    this()
-    this.firstName = firstName
-    this.lastName = lastName
+  // Need to specify an empty constructor
+  def this() {
+    this(0, "", "")
   }
-
-  // BeanProperty needed to generate getters and setters
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  @BeanProperty
-  var id: Long = _
-
-  @BeanProperty
-  var firstName: String = _
-
-  @BeanProperty
-  var lastName: String = _
 
   @JsonIgnore
   @OneToMany(mappedBy = "owner")
   @BeanProperty
   var pets: java.util.List[Pet] = _
 
-  override def toString(): String = s"$firstName $lastName"
+  override def toString: String = s"$firstName $lastName"
+
 }

--- a/pet-clinic-scala/src/main/scala/com/github/rskupnik/model/Pet.scala
+++ b/pet-clinic-scala/src/main/scala/com/github/rskupnik/model/Pet.scala
@@ -2,27 +2,28 @@ package com.github.rskupnik.model
 
 import javax.persistence._
 
+import scala.annotation.meta.field
 import scala.beans.BeanProperty
 
 @Entity
-class Pet {
+case class Pet(
+                @(Id@field)
+                @(GeneratedValue@field)
+                @BeanProperty
+                var id: Long,
+                @BeanProperty
+                var name: String) {
 
-  def this(name: String, owner: Customer) {
-    this()
-    this.name = name
-    this.owner = owner
+  // Need to specify an empty constructor
+  def this() {
+    this(0, "")
   }
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  @BeanProperty
-  var id: Long = _
-
-  @BeanProperty
-  var name: String = _
 
   @ManyToOne
   @JoinColumn(name = "ownerId", nullable = false)
   @BeanProperty
   var owner: Customer = _
+
+  override def toString: String = name
+
 }


### PR DESCRIPTION
Added the toString method that both the Java and Kotlin example have on Pet.

Removed explicit strategy on the GeneratedValue annotation, since it is the default anyway.

NOTE: For the Hibernate annotations to work on class parameters you have to use a Scala 'field' annotation. It is possible to create type aliases, to make this look nicer, but it feels a bit like cheating.